### PR TITLE
readme points to correct file

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Install
 Download, review, then execute the script:
 
 ```sh
-curl --remote-name https://raw.githubusercontent.com/thoughtbot/laptop/master/mac
+curl --remote-name https://raw.githubusercontent.com/nathanborgo/laptop/master/mac
 less mac
 sh mac 2>&1 | tee ~/laptop.log
 ```


### PR DESCRIPTION
The old readme instructed the user to download the thoughtbot version of the script rather than the nathanborgo version. It's fixed here.